### PR TITLE
fix for issue #94 (ID3 size coding): do not use syncsafe for frame si…

### DIFF
--- a/libs/libid3/id3.c
+++ b/libs/libid3/id3.c
@@ -614,8 +614,15 @@ int id3_write_tag(struct id3_tag *id3, uint8_t *buffer)
         memcpy(raw, fr->fr_desc->fd_idstr, 4);
         raw += 4;
 
-        // Add the frame size (syncsafe).
-        ID3_SET_SIZE28(fr->fr_size, raw[0], raw[1], raw[2], raw[3]);
+        // Add the frame size (version 2.4 uses syncsafe frame size, so we do that, but I don't think 2.4 is fully supported).
+        if (id3->id3_version == 4)
+            ID3_SET_SIZE28(fr->fr_size, raw[0], raw[1], raw[2], raw[3]);
+        else {
+            raw[0] = fr->fr_size >> 24;
+            raw[1] = fr->fr_size >> 16;
+            raw[2] = fr->fr_size >> 8;
+            raw[3] = fr->fr_size;
+        }
         raw += 4;
 
         // The two flagbytes.

--- a/libs/libid3/id3_frame.c
+++ b/libs/libid3/id3_frame.c
@@ -292,8 +292,13 @@ int id3_read_frame(struct id3_tag *id3)
 	frame = calloc(sizeof(*frame), 1);
 
 	frame->fr_owner = id3;
-	/* FIXME v2.4.0 */
-	frame->fr_raw_size = buf[4] << 24 | buf[5] << 16 | buf[6] << 8 | buf[7];
+
+	/* revision 2.4 uses syncsafe frame size, so we do that, but I don't think 2.4 is fully supported */
+	if (id3->id3_version == 4)
+		frame->fr_raw_size = ID3_GET_SIZE28(buf[4], buf[5], buf[6], buf[7]);
+	else
+		frame->fr_raw_size = buf[4] << 24 | buf[5] << 16 | buf[6] << 8 | buf[7];
+
 	if (frame->fr_raw_size > 1000000)
 	{
 		free(frame);


### PR DESCRIPTION
…ze (v2.3)