### PR TITLE
Enabling GCC compiler optimization and adding padding-less DSF generation option

### DIFF
--- a/libs/libid3/id3.c
+++ b/libs/libid3/id3.c
@@ -614,8 +614,15 @@ int id3_write_tag(struct id3_tag *id3, uint8_t *buffer)
         memcpy(raw, fr->fr_desc->fd_idstr, 4);
         raw += 4;
 
-        // Add the frame size (syncsafe).
-        ID3_SET_SIZE28(fr->fr_size, raw[0], raw[1], raw[2], raw[3]);
+        // Add the frame size (version 2.4 uses syncsafe frame size, so we do that, but I don't think 2.4 is fully supported).
+        if (id3->id3_version == 4)
+            ID3_SET_SIZE28(fr->fr_size, raw[0], raw[1], raw[2], raw[3]);
+        else {
+            raw[0] = fr->fr_size >> 24;
+            raw[1] = fr->fr_size >> 16;
+            raw[2] = fr->fr_size >> 8;
+            raw[3] = fr->fr_size;
+        }
         raw += 4;
 
         // The two flagbytes.

--- a/libs/libid3/id3_frame.c
+++ b/libs/libid3/id3_frame.c
@@ -292,8 +292,13 @@ int id3_read_frame(struct id3_tag *id3)
 	frame = calloc(sizeof(*frame), 1);
 
 	frame->fr_owner = id3;
-	/* FIXME v2.4.0 */
-	frame->fr_raw_size = buf[4] << 24 | buf[5] << 16 | buf[6] << 8 | buf[7];
+
+	/* revision 2.4 uses syncsafe frame size, so we do that, but I don't think 2.4 is fully supported */
+	if (id3->id3_version == 4)
+		frame->fr_raw_size = ID3_GET_SIZE28(buf[4], buf[5], buf[6], buf[7]);
+	else
+		frame->fr_raw_size = buf[4] << 24 | buf[5] << 16 | buf[6] << 8 | buf[7];
+
 	if (frame->fr_raw_size > 1000000)
 	{
 		free(frame);

--- a/libs/libsacd/dsf.c
+++ b/libs/libsacd/dsf.c
@@ -161,29 +161,55 @@ static int dsf_create_header(scarletbook_output_format_t *ft)
     return 0;
 }
 
+uint8_t buffer_prev[MAX_CHANNEL_COUNT][SACD_BLOCK_SIZE_PER_CHANNEL];
+uint8_t *buffer_ptr_prev[MAX_CHANNEL_COUNT];
 
 static int dsf_create(scarletbook_output_format_t *ft)
 {
+    int i;
+    dsf_handle_t *handle = (dsf_handle_t *) ft->priv;
+
+
+    // If this is not the first track, carry over the leftover samples from the tail of the previous track for no zero padding.
+    if(ft->track && ft->dsf_nopad){
+        for(i = 0; i < MAX_CHANNEL_COUNT; i++){
+            memcpy(handle->buffer[i], buffer_prev[i], SACD_BLOCK_SIZE_PER_CHANNEL * sizeof(uint8_t));
+            handle->buffer_ptr[i] = handle->buffer[i] + (buffer_ptr_prev[i] - buffer_prev[i]);
+        }
+    }
+
     return dsf_create_header(ft);
 }
 
 static int dsf_close(scarletbook_output_format_t *ft)
 {
     dsf_handle_t *handle = (dsf_handle_t *) ft->priv;
+    scarletbook_handle_t *sb_handle = ft->sb_handle;
     int i;
 
-    // write out what was left in the ring buffers
-    for (i = 0; i < handle->channel_count; i++)
-    {
-	if (handle->buffer_ptr[i] > handle->buffer[i]) {
-	    handle->sample_count += handle->buffer_ptr[i] - handle->buffer[i];
+    // Save the remaining samples in the buffer to be attached to the beginning of the next track.
+    // This is needed for padding-less DSF generation.  This is for players that cannot handle zero-padding properly. 
+    if(ft->dsf_nopad && ft->track < sb_handle->area[ft->area].area_toc->track_count - 1){
+        for(i = 0; i < MAX_CHANNEL_COUNT; i ++){
+            memcpy(buffer_prev[i], handle->buffer[i], SACD_BLOCK_SIZE_PER_CHANNEL);
+            buffer_ptr_prev[i] = buffer_prev[i] + (handle->buffer_ptr[i] - handle->buffer[i]);
+        }
+    }
+    else{
+        // Write out what was left in the ring buffers if dsf_nopad = 0
+        // This does zero fill to make the last block size 4096 bytes which leads to pop noise in some players (as in 0.3.8).
+        for (i = 0; i < handle->channel_count; i++)
+        {
+	        if (handle->buffer_ptr[i] > handle->buffer[i]) {
+	            handle->sample_count += handle->buffer_ptr[i] - handle->buffer[i];
 
-	    fwrite(handle->buffer[i], 1, SACD_BLOCK_SIZE_PER_CHANNEL, ft->fd);
-	    memset(handle->buffer[i], 0, SACD_BLOCK_SIZE_PER_CHANNEL);
+	            fwrite(handle->buffer[i], 1, SACD_BLOCK_SIZE_PER_CHANNEL, ft->fd);
+	            memset(handle->buffer[i], 0, SACD_BLOCK_SIZE_PER_CHANNEL);
 
-	    handle->buffer_ptr[i] = handle->buffer[i];
-	    handle->audio_data_size += SACD_BLOCK_SIZE_PER_CHANNEL;
-	}
+	            handle->buffer_ptr[i] = handle->buffer[i];
+	            handle->audio_data_size += SACD_BLOCK_SIZE_PER_CHANNEL;
+	        }
+        }
     }
 
     // write the footer

--- a/libs/libsacd/scarletbook_output.c
+++ b/libs/libsacd/scarletbook_output.c
@@ -122,7 +122,7 @@ static void destroy_ripping_queue(scarletbook_output_t *output)
     }
 }
 
-int scarletbook_output_enqueue_track(scarletbook_output_t *output, int area, int track, char *file_path, char *fmt, int dsd_encoded_export)
+int scarletbook_output_enqueue_track(scarletbook_output_t *output, int area, int track, char *file_path, char *fmt, int dsd_encoded_export, int dsf_nopad)
 {
     scarletbook_format_handler_t const * handler;
     scarletbook_output_format_t * output_format_ptr;
@@ -140,6 +140,7 @@ int scarletbook_output_enqueue_track(scarletbook_output_t *output, int area, int
         output_format_ptr->channel_count = sb_handle->area[area].area_toc->channel_count;
         output_format_ptr->dst_encoded_import = sb_handle->area[area].area_toc->frame_format == FRAME_FORMAT_DST;
         output_format_ptr->dsd_encoded_export = dsd_encoded_export;
+        output_format_ptr->dsf_nopad = dsf_nopad;
         if (handler->flags & OUTPUT_FLAG_EDIT_MASTER)
         {
             output_format_ptr->start_lsn = sb_handle->area[area].area_toc->track_start;

--- a/libs/libsacd/scarletbook_output.h
+++ b/libs/libsacd/scarletbook_output.h
@@ -87,6 +87,8 @@ struct scarletbook_output_format_t
     scarletbook_handle_t           *sb_handle;
     fwprintf_callback_t             cb_fwprintf;
 
+    int                             dsf_nopad;
+
     struct list_head                siblings;
 }; 
 
@@ -97,7 +99,7 @@ typedef void (*stats_track_callback_t)(char *filename, int current_track, int to
 
 scarletbook_output_t *scarletbook_output_create(scarletbook_handle_t *, stats_track_callback_t, stats_progress_callback_t, fwprintf_callback_t);
 int scarletbook_output_destroy(scarletbook_output_t *);
-int scarletbook_output_enqueue_track(scarletbook_output_t *, int, int, char *, char *, int);
+int scarletbook_output_enqueue_track(scarletbook_output_t *, int, int, char *, char *, int, int);
 int scarletbook_output_enqueue_raw_sectors(scarletbook_output_t *, int, int, char *, char *);
 int scarletbook_output_start(scarletbook_output_t *);
 void scarletbook_output_interrupt(scarletbook_output_t *);

--- a/tools/sacd_extract/CMakeLists.txt
+++ b/tools/sacd_extract/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories("../../libs/libsacd")
 if (CMAKE_COMPILER_IS_GNUCC)
   add_definitions(
       -pipe
-      -Wall -Wextra -Wcast-align -Wpointer-arith
+      -Wall -Wextra -Wcast-align -Wpointer-arith -O3
       -Wno-unused-parameter -msse2)
 endif (CMAKE_COMPILER_IS_GNUCC)
 


### PR DESCRIPTION
Enabling GCC compiler optimization in CMakeLists.txt.  This provides about a 3X performance improvement in DST decoding for Linux and likely macOS.

Adding -z option to avoid zero padding at the tail of a DSF by carrying the leftover samples at the tail of a track to the head of the next track.  This addresses the issue that some players cannot properly handle zero padding in DSF and produce a pop noise at a track transition.  This option cannot be used with -t because continuous decoding is required for this option to work.  This is a loss-less process.