### PR TITLE
Externalize definitions in scarletbook.h

### DIFF
--- a/libs/libsacd/scarletbook.h
+++ b/libs/libsacd/scarletbook.h
@@ -73,7 +73,7 @@
 
 #define MAX_PROCESSING_BLOCK_SIZE      512
 
-enum
+extern enum
 {
       FRAME_FORMAT_DST         = 0
     , FRAME_FORMAT_DSD_3_IN_14 = 2
@@ -81,7 +81,7 @@ enum
 } 
 frame_format_t;
 
-enum
+extern enum
 {
       CHAR_SET_UNKNOWN       = 0
     , CHAR_SET_ISO646        = 1    // ISO 646 (IRV), no escape sequences allowed
@@ -99,7 +99,7 @@ extern const char *character_set[];
 
 extern const char *album_genre[];
 
-enum
+extern enum
 {
       GENRE_NOT_USED               = 0       // 12
     , GENRE_NOT_DEFINED            = 1       // 12
@@ -134,7 +134,7 @@ enum
 } 
 genre_t;
 
-enum
+extern enum
 {
       CATEGORY_NOT_USED = 0
     , CATEGORY_GENERAL  = 1
@@ -144,7 +144,7 @@ category_t;
 
 extern const char *album_category[];
 
-enum
+extern enum
 {
       TRACK_TYPE_TITLE                  = 0x01
     , TRACK_TYPE_PERFORMER              = 0x02
@@ -469,7 +469,7 @@ typedef struct
 } 
 ATTRIBUTE_PACKED area_tracklist_t;
 
-enum
+extern enum
 {
       DATA_TYPE_AUDIO           = 2
     , DATA_TYPE_SUPPLEMENTARY   = 3


### PR DESCRIPTION
Solves `multiple definitions` errors in make during linkage of C executables.

Disclaimer: I am not very experienced in C++, so I might be using the wring jargon. The commit solves the error though. 